### PR TITLE
Update php version for D8

### DIFF
--- a/islandora_solr_facet_pages.info.yml
+++ b/islandora_solr_facet_pages.info.yml
@@ -5,5 +5,5 @@ dependencies:
 package: Islandora
 configure: islandora_solr_facet_pages.admin_settings
 core: 8.x
-php: '5.5.9'
+php: '7.2'
 type: module


### PR DESCRIPTION
php 5 support is being dropped:
[Drupal docs](https://www.drupal.org/docs/8/system-requirements/php-requirements)