### PR TITLE
Adding 'menu' class to the facet pages menu block

### DIFF
--- a/src/Plugin/Block/ListFacetPages.php
+++ b/src/Plugin/Block/ListFacetPages.php
@@ -32,11 +32,14 @@ class ListFacetPages extends AbstractConfiguredBlockBase {
       ->addCacheableDependency($config);
 
     $block = [
-      '#theme' => 'item_list',
-      '#items' => array_map([$this, 'mapConfigItemToRenderArray'], $fields),
-      '#list_type' => 'ul',
-      '#wrapper_attributes' => [
-        'class' => 'islandora-solr-facet-pages-list',
+      'list' => [
+        '#theme' => 'item_list',
+        '#items' => array_map([$this, 'mapConfigItemToRenderArray'], $fields),
+        '#list_type' => 'ul',
+        '#attributes' => ['class' => ['menu']],
+        '#wrapper_attributes' => [
+          'class' => 'islandora-solr-facet-pages-list',
+        ],
       ],
     ];
 


### PR DESCRIPTION
Menu link class in solr facet pages menu link block.

# What does this Pull Request do?
Adds a standard 'menu' class to the solr facet pages block menu unordered list.

# What's new?
New class added to the menu link menu.

# How should this be tested?
- Inspect the code in the solr facet pages block. The 'ul' should now have a class of 'menu'.

# Interested parties
Tag (@willtp87 )
